### PR TITLE
Fix meta image path to absolute

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
     
     <meta property="og:title" content="277 - Your Challenges, Our Focus">
     <meta property="og:description" content="277 is where business challenges find understanding and solutions. A dedicated team of empaths, hackers, and innovators focused on addressing unique problems.">
-    <meta property="og:image" content="assets/og.png">
+    <meta property="og:image" content="https://whatis277.com/assets/og.png">
     <meta property="og:url" content="https://whatis277.com/">
 
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="277 - Your Challenges, Our Focus">
     <meta name="twitter:description" content="277 is where business challenges find understanding and solutions. A dedicated team of empaths, hackers, and innovators focused on addressing unique problems.">
-    <meta name="twitter:image" content="assets/twitter.png">
+    <meta name="twitter:image" content="https://whatis277.com/assets/twitter.png">
 
     <title>277</title>
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />


### PR DESCRIPTION
### Description

The image path for `og:image` and `twitter:image` should be absolute, instead of relative. Fixes that.